### PR TITLE
When using Siri, nil username/password is crashing

### DIFF
--- a/OctoPod/OctoPrint/HTTPClient.swift
+++ b/OctoPod/OctoPrint/HTTPClient.swift
@@ -266,7 +266,7 @@ class HTTPClient: NSObject, URLSessionTaskDelegate {
             NSLog("Alert Please check the credential")
             completionHandler(Foundation.URLSession.AuthChallengeDisposition.cancelAuthenticationChallenge, nil)
         } else {
-            let credential = URLCredential(user: self.username!, password: self.password!, persistence: .forSession)
+            let credential = URLCredential(user: self.username ?? "", password: self.password ?? "", persistence: .forSession)
             completionHandler(Foundation.URLSession.AuthChallengeDisposition.useCredential, credential)
         }
     }


### PR DESCRIPTION
- This does not seem like the correct cure, but to avoid force-unwrapping
  nil values, pass in an empty string when username and password are nil.
- This only seems an issue when using Siri.