### PR TITLE
Format command preserving value tokens

### DIFF
--- a/OctoPod/Terminal UI/TerminalViewController.swift
+++ b/OctoPod/Terminal UI/TerminalViewController.swift
@@ -113,8 +113,9 @@ class TerminalViewController: UIViewController, OctoPrintClientDelegate, AppConf
             showCommandsHistory(show: false)
 
             // Format the command by uppercasing the tokens except possible label values
-            let commandTokens = string.split(separator: " ")
+            let commandTokens = text.split(separator: " ")
 
+            // Convert to uppercase any words without = or the key part before = and leave the rest as is
             let commandAry : [String] = commandTokens.map {
                 if $0.contains("=") {
                     var tokens = $0.components(separatedBy: "=")

--- a/OctoPod/Terminal UI/TerminalViewController.swift
+++ b/OctoPod/Terminal UI/TerminalViewController.swift
@@ -111,8 +111,21 @@ class TerminalViewController: UIViewController, OctoPrintClientDelegate, AppConf
             gcodeField.endEditing(true)
             // Hide history of sent commands
             showCommandsHistory(show: false)
+
+            // Format the command by uppercasing the tokens except possible label values
+            let commandTokens = string.split(separator: " ")
+
+            let commandAry : [String] = commandTokens.map {
+                if $0.contains("=") {
+                    var tokens = $0.components(separatedBy: "=")
+                    tokens[0] = tokens[0].uppercased()
+                    return tokens.joined(separator: "=")
+                } else {
+                    return $0.uppercased()
+                }
+            }
             // Send command to OctoPrint
-            let command = text.uppercased()
+            let command = commandAry.joined(separator: " ")
             octoprintClient.sendCommand(gcode: command) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if !requested {
                     // Handle error


### PR DESCRIPTION
When using Klipper, some values of the internal GCode commands cannot be force-uppercased as values are case-sensitive in Klipper.

This change preserves those values, for example:

Sending this

```
stEpper_buZZ Stepper=sTepper_x x=123    anotheR=val1
```

would result in uppercasing the labels and command while preserving the values:

```
STEPPER_BUZZ STEPPER=sTepper_x X=123 ANOTHER=val1
```

Closes https://github.com/gdombiak/OctoPod/issues/327

I have never written any Swift code before, so please let me know if there's a better way of doing it.