### PR TITLE
Enable slide over & split view on iPad (single instance)

### DIFF
--- a/OctoPod/Info.plist
+++ b/OctoPod/Info.plist
@@ -87,7 +87,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Saw other issues mentioning multi instance etc.  This PR just allows OctoPod to be used split with other app's, it won't cause an issue if multi instance is added later.