### PR TITLE
fixing generator.impactOccurred() crash on iOS 11.*

### DIFF
--- a/OctoPod/Move UI/MoveSubViewController.swift
+++ b/OctoPod/Move UI/MoveSubViewController.swift
@@ -226,9 +226,7 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
             octoprintClient.move(z: delta) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
                     DispatchQueue.main.async {
-                        DispatchQueue.main.async {
                             generator.impactOccurred()
-                        }
                     }
                 } else {
                     // Handle error

--- a/OctoPod/Move UI/MoveSubViewController.swift
+++ b/OctoPod/Move UI/MoveSubViewController.swift
@@ -133,7 +133,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
             let generator = prepareGenerator(delta)
             octoprintClient.move(y: delta) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.impactOccurred()
+                    DispatchQueue.main.async {
+                        generator.impactOccurred()
+                    }
                 } else {
                     // Handle error
                     NSLog("Error moving Y axis. HTTP status code \(response.statusCode)")
@@ -149,7 +151,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
             let generator = prepareGenerator(delta)
             octoprintClient.move(y: delta) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.impactOccurred()
+                    DispatchQueue.main.async {
+                        generator.impactOccurred()
+                    }
                 } else {
                     // Handle error
                     NSLog("Error moving Y axis. HTTP status code \(response.statusCode)")
@@ -165,7 +169,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
             let generator = prepareGenerator(delta)
             octoprintClient.move(x: delta) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.impactOccurred()
+                    DispatchQueue.main.async {
+                        generator.impactOccurred()
+                    }
                 } else {
                     // Handle error
                     NSLog("Error moving X axis. HTTP status code \(response.statusCode)")
@@ -181,7 +187,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
             let generator = prepareGenerator(delta)
             octoprintClient.move(x: delta) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.impactOccurred()
+                    DispatchQueue.main.async {
+                        generator.impactOccurred()
+                    }
                 } else {
                     // Handle error
                     NSLog("Error moving X axis. HTTP status code \(response.statusCode)")
@@ -199,7 +207,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
             let generator = prepareGenerator(delta)
             octoprintClient.move(z: delta) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.impactOccurred()
+                    DispatchQueue.main.async {
+                        generator.impactOccurred()
+                    }
                 } else {
                     // Handle error
                     NSLog("Error moving Z axis. HTTP status code \(response.statusCode)")
@@ -215,7 +225,11 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
             let generator = prepareGenerator(delta)
             octoprintClient.move(z: delta) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.impactOccurred()
+                    DispatchQueue.main.async {
+                        DispatchQueue.main.async {
+                            generator.impactOccurred()
+                        }
+                    }
                 } else {
                     // Handle error
                     NSLog("Error moving Z axis. HTTP status code \(response.statusCode)")
@@ -230,7 +244,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.home(axes: ["x", "y", "z"]) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error going home. HTTP status code \(response.statusCode)")
@@ -244,7 +260,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.home(axes: ["x"]) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error going home X. HTTP status code \(response.statusCode)")
@@ -258,7 +276,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.home(axes: ["y"]) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error going home Y. HTTP status code \(response.statusCode)")
@@ -272,7 +292,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.home(axes: ["z"]) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error going home Z. HTTP status code \(response.statusCode)")
@@ -358,7 +380,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.toolFlowRate(toolNumber: 0, newFlowRate: newFlowRate, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error setting new flow rate. HTTP status code \(response.statusCode)")
@@ -381,7 +405,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.fanSpeed(speed: newSpeed, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error setting new fan speed. HTTP status code \(response.statusCode)")
@@ -460,7 +486,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.feedRate(factor: newRate, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error setting new feed rate. HTTP status code \(response.statusCode)")
@@ -642,7 +670,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         generator.prepare()
         octoprintClient.disableMotor(axis: axis, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 // Handle error
                 NSLog("Error disabling \(axis) motor. HTTP status code \(response.statusCode)")
@@ -670,7 +700,9 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
         let generator = prepareGenerator(Float(delta))
         octoprintClient.extrude(toolNumber: toolNumber, delta: delta, speed: speed, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.impactOccurred()
+                DispatchQueue.main.async {
+                    generator.impactOccurred()
+                }
             } else {
                 // Handle error
                 NSLog("Error moving E axis. HTTP status code \(response.statusCode)")

--- a/OctoPod/Panel UI/PanelViewController.swift
+++ b/OctoPod/Panel UI/PanelViewController.swift
@@ -250,9 +250,13 @@ class PanelViewController: UIViewController, UIPopoverPresentationControllerDele
             case SetTargetTempViewController.TargetScope.bed:
                 octoprintClient.bedTargetTemperature(newTarget: newTarget) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
-                        generator.notificationOccurred(.error)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.error)
+                        }
                         NSLog("Failed to request setting bed's temperature. Response: \(response)")
                     }
                 }
@@ -263,9 +267,13 @@ class PanelViewController: UIViewController, UIPopoverPresentationControllerDele
             case SetTargetTempViewController.TargetScope.tool0:
                 octoprintClient.toolTargetTemperature(toolNumber: 0, newTarget: newTarget) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
-                        generator.notificationOccurred(.error)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.error)
+                        }
                         NSLog("Failed to request setting tool0's temperature. Response: \(response)")
                     }
                 }
@@ -276,9 +284,13 @@ class PanelViewController: UIViewController, UIPopoverPresentationControllerDele
             case SetTargetTempViewController.TargetScope.tool1:
                 octoprintClient.toolTargetTemperature(toolNumber: 1, newTarget: newTarget) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
-                        generator.notificationOccurred(.error)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.error)
+                        }
                         NSLog("Failed to request setting tool1's temperature. Response: \(response)")
                     }
                 }
@@ -289,9 +301,13 @@ class PanelViewController: UIViewController, UIPopoverPresentationControllerDele
             case SetTargetTempViewController.TargetScope.tool2:
                 octoprintClient.toolTargetTemperature(toolNumber: 2, newTarget: newTarget) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
-                        generator.notificationOccurred(.error)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.error)
+                        }
                         NSLog("Failed to request setting tool2's temperature. Response: \(response)")
                     }
                 }
@@ -302,9 +318,13 @@ class PanelViewController: UIViewController, UIPopoverPresentationControllerDele
             case SetTargetTempViewController.TargetScope.tool3:
                 octoprintClient.toolTargetTemperature(toolNumber: 3, newTarget: newTarget) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
-                        generator.notificationOccurred(.error)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.error)
+                        }
                         NSLog("Failed to request setting tool3's temperature. Response: \(response)")
                     }
                 }
@@ -315,9 +335,13 @@ class PanelViewController: UIViewController, UIPopoverPresentationControllerDele
             case SetTargetTempViewController.TargetScope.tool4:
                 octoprintClient.toolTargetTemperature(toolNumber: 4, newTarget: newTarget) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
-                        generator.notificationOccurred(.error)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.error)
+                        }
                         NSLog("Failed to request setting tool4's temperature. Response: \(response)")
                     }
                 }
@@ -328,9 +352,13 @@ class PanelViewController: UIViewController, UIPopoverPresentationControllerDele
             case SetTargetTempViewController.TargetScope.chamber:
                 octoprintClient.chamberTargetTemperature(newTarget: newTarget) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
-                        generator.notificationOccurred(.error)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.error)
+                        }
                         NSLog("Failed to request setting chamber's temperature. Response: \(response)")
                     }
                 }

--- a/OctoPod/Panel UI/Subpanels/Custom Controls/ChildrenCustomControlViewController.swift
+++ b/OctoPod/Panel UI/Subpanels/Custom Controls/ChildrenCustomControlViewController.swift
@@ -84,7 +84,9 @@ class ChildrenCustomControlViewController: ThemedDynamicUITableViewController {
                     let json = control.executePayload()
                     self.octoprintClient.executeCustomControl(control: json, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                         if requested {
-                            generator.notificationOccurred(.success)
+                            DispatchQueue.main.async {
+                                generator.notificationOccurred(.success)
+                            }
                         } else {
                             // Handle error
                             NSLog("Error requesting to execute command \(json). HTTP status code \(response.statusCode)")

--- a/OctoPod/Panel UI/Subpanels/Custom Controls/ExecuteControlViewController.swift
+++ b/OctoPod/Panel UI/Subpanels/Custom Controls/ExecuteControlViewController.swift
@@ -108,7 +108,9 @@ class ExecuteControlViewController: ThemedDynamicUITableViewController {
             let json = self.control.executePayload()
             self.octoprintClient.executeCustomControl(control: json, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.notificationOccurred(.success)
+                    DispatchQueue.main.async {
+                        generator.notificationOccurred(.success)
+                    }
                 } else {
                     // Handle error
                     NSLog("Error requesting to execute command \(json). HTTP status code \(response.statusCode)")

--- a/OctoPod/Panel UI/Subpanels/EnclosureViewController.swift
+++ b/OctoPod/Panel UI/Subpanels/EnclosureViewController.swift
@@ -127,7 +127,9 @@ class EnclosureViewController : ThemedDynamicUITableViewController, SubpanelView
                     generator.prepare()
                     self.octoprintClient.changeEnclosureGPIO(index_id: output.index, status: !on) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                         if requested {
-                            generator.notificationOccurred(.success)
+                           DispatchQueue.main.async {
+                                generator.notificationOccurred(.success)
+                            }
                             // Update in memory status
                             output.status = !on
                             // Refresh row
@@ -162,8 +164,8 @@ class EnclosureViewController : ThemedDynamicUITableViewController, SubpanelView
                 generator.prepare()
                 self.octoprintClient.changeEnclosurePWM(index_id: output.index, dutyCycle: dutyCycle) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
                         DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
                             // Clean up value of cell
                             cell.pwmField.text = nil
                             // Refresh row

--- a/OctoPod/Panel UI/Subpanels/PrinterSubpanelViewController.swift
+++ b/OctoPod/Panel UI/Subpanels/PrinterSubpanelViewController.swift
@@ -513,7 +513,9 @@ class PrinterSubpanelViewController: ThemedStaticUITableViewController, UIPopove
             generator.prepare()
             self.octoprintClient.restartCurrentJob { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.notificationOccurred(.success)
+                    DispatchQueue.main.async {
+                        generator.notificationOccurred(.success)
+                    }
                 } else {
                     NSLog("Error requesting to restart current job: \(String(describing: error?.localizedDescription)). Http response: \(response.statusCode)")
                     self.showAlert(NSLocalizedString("Job", comment: ""), message: NSLocalizedString("Notify failed restart job", comment: ""))
@@ -532,7 +534,9 @@ class PrinterSubpanelViewController: ThemedStaticUITableViewController, UIPopove
         generator.prepare()
         self.octoprintClient.pauseCurrentJob { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 NSLog("Error requesting to pause current job: \(String(describing: error?.localizedDescription)). Http response: \(response.statusCode)")
                 self.showAlert(NSLocalizedString("Job", comment: ""), message: NSLocalizedString("Notify failed pause job", comment: ""))
@@ -549,7 +553,9 @@ class PrinterSubpanelViewController: ThemedStaticUITableViewController, UIPopove
             generator.prepare()
             self.octoprintClient.cancelCurrentJob { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.notificationOccurred(.success)
+                    DispatchQueue.main.async {
+                        generator.notificationOccurred(.success)
+                    }
                 } else {
                     NSLog("Error requesting to cancel current job: \(String(describing: error?.localizedDescription)). Http response: \(response.statusCode)")
                     self.showAlert(NSLocalizedString("Job", comment: ""), message: NSLocalizedString("Notify failed cancel job", comment: ""))
@@ -569,7 +575,9 @@ class PrinterSubpanelViewController: ThemedStaticUITableViewController, UIPopove
             generator.prepare()
             self.octoprintClient.printFile(origin: lastFile.origin!, path: lastFile.path!) { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                 if requested {
-                    generator.notificationOccurred(.success)
+                    DispatchQueue.main.async {
+                        generator.notificationOccurred(.success)
+                    }
                 } else {
                     NSLog("Error requesting to reprint file: \(String(describing: error?.localizedDescription)). Http response: \(response.statusCode)")
                     self.showAlert(NSLocalizedString("Job", comment: ""), message: NSLocalizedString("Notify failed print job again", comment: ""))
@@ -583,7 +591,9 @@ class PrinterSubpanelViewController: ThemedStaticUITableViewController, UIPopove
         generator.prepare()
         self.octoprintClient.resumeCurrentJob { (requested: Bool, error: Error?, response: HTTPURLResponse) in
             if requested {
-                generator.notificationOccurred(.success)
+                DispatchQueue.main.async {
+                    generator.notificationOccurred(.success)
+                }
             } else {
                 NSLog("Error requesting to resume current job: \(String(describing: error?.localizedDescription)). Http response: \(response.statusCode)")
                 self.showAlert(NSLocalizedString("Job", comment: ""), message: NSLocalizedString("Notify failed resume job", comment: ""))

--- a/OctoPod/Panel UI/Subpanels/SystemCommandsViewController.swift
+++ b/OctoPod/Panel UI/Subpanels/SystemCommandsViewController.swift
@@ -62,7 +62,9 @@ class SystemCommandsViewController: ThemedDynamicUITableViewController, Subpanel
                 generator.prepare()
                 self.octoprintClient.executeSystemCommand(command: command, callback: { (requested: Bool, error: Error?, response: HTTPURLResponse) in
                     if requested {
-                        generator.notificationOccurred(.success)
+                        DispatchQueue.main.async {
+                            generator.notificationOccurred(.success)
+                        }
                     } else {
                         // Handle error
                         NSLog("Error executing system command. HTTP status code \(response.statusCode)")


### PR DESCRIPTION
OctoPrint has been crashing in certain iPhones running IOS 11.* due to the problem described here  https://stackoverflow.com/questions/40273911/uifeedback-haptic-engine-called-more-times-than-was-activated 