### PR TITLE
upload a gcode file received via iOS/iPadOS share feature

### DIFF
--- a/OctoPod/AppDelegate.swift
+++ b/OctoPod/AppDelegate.swift
@@ -129,9 +129,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         else if url.pathExtension == "gcode" {
             // User has shared a gcode-file with Octopod. The only useful operation is to upload to octoprint.
-            // Add some delay so app transitions to Active (camera will render only when app is active)
+            // Add some delay so app transitions to Active
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                //self.defaultPrinterManager.changeToDefaultPrinter(printer: printer)
 
                 // Go to main Panel window
                 if let tabBarController = self.window!.rootViewController as? UITabBarController {
@@ -143,10 +142,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     }
                 }
             }
-
-            // As the gcode-file is not necessarily in octopod directories, this fancy AccessingSecurityScopedResource is necessary.
-            _ = url.startAccessingSecurityScopedResource()
-            url.stopAccessingSecurityScopedResource()
         }
         return false
     }

--- a/OctoPod/AppDelegate.swift
+++ b/OctoPod/AppDelegate.swift
@@ -127,6 +127,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 return true
             }
         }
+        else if url.pathExtension == "gcode" {
+            // User has shared a gcode-file with Octopod. The only useful operation is to upload to octoprint.
+            // Add some delay so app transitions to Active (camera will render only when app is active)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                //self.defaultPrinterManager.changeToDefaultPrinter(printer: printer)
+
+                // Go to main Panel window
+                if let tabBarController = self.window!.rootViewController as? UITabBarController {
+                    tabBarController.selectedIndex = 3
+                    if let navigationVC = tabBarController.selectedViewController as? NavigationController, let panelVC = navigationVC.topViewController as? FilesTreeViewController {
+                        // To avoid Storyboard modification, just reuse existing segue
+                        panelVC.uploadURL = url
+                        panelVC.performSegue(withIdentifier: "gotoUploadLocation", sender: self)
+                    }
+                }
+            }
+
+            // As the gcode-file is not necessarily in octopod directories, this fancy AccessingSecurityScopedResource is necessary.
+            _ = url.startAccessingSecurityScopedResource()
+            url.stopAccessingSecurityScopedResource()
+        }
         return false
     }
 

--- a/OctoPod/Info.plist
+++ b/OctoPod/Info.plist
@@ -6,6 +6,19 @@
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
 	<string>OctoPod</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>GCODE</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.gcode</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -122,6 +135,28 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Gcode-File</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>public.gcode</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>gcode</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
In reference to #597: This PR presents a quick implementation for the share feature to quickly upload a gcode file. This works in these steps:
1. access in iOS file manager a gcode file
2. open the share menu in file manager
3. In share menu select octopod, this transitions to octopod
4. in octopod select upload file popover menu item

From the slicer, it does not work yet, but this may be slicer related or still some wrong definitions. For sure the whole UTTypeIdentifier/Document/Imported Type Identifiers is not self-explaining. So there may be issues on either side.

Two additional notes:
* The formatting of two files has been slightly changed due to use of swift-format
* The Xcode 14.0 Beta 4 yields two compile errors, while Xcode 13 compiles:
   1. ChartDataSet.swift:530:1: error build: Type 'ChartDataSet' does not conform to protocol 'RangeReplaceableCollection'
   2. ChartDataSet.swift:530:1: error build: Unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'

Please comment
