### PR TITLE
Supporting OctoRelay API v2 with backward compatibility

### DIFF
--- a/OctoPod/Model/Octorelay.swift
+++ b/OctoPod/Model/Octorelay.swift
@@ -7,7 +7,8 @@ class Octorelay {
     private(set) var name: String
     
     static func parse(json: NSDictionary) -> Octorelay? {
-        if let id = json["id"] as? String, let name = json["name"] as? String, let active = json["active"] as? Bool {
+        // json["active"] is for backward compatibility to API v1
+        if let id = json["id"] as? String, let name = json["name"] as? String, let active = (json["status"] ?? json["active"]) as? Bool {
             return Octorelay(id: id, active: active, name: name)
         }
         return nil

--- a/OctoPod/OctoPrint/OctoPrintRESTClient.swift
+++ b/OctoPod/OctoPrint/OctoPrintRESTClient.swift
@@ -836,6 +836,7 @@ class OctoPrintRESTClient {
         if let client = httpClient {
             let json : NSMutableDictionary = NSMutableDictionary()
             json["command"] = "listAllStatus"
+            json["version"] = 2
             client.post("/api/plugin/octorelay", json: json, expected: 200) { (result: NSObject?, error: Error?, response: HTTPURLResponse) in
                 // Check if there was an error
                 if let _ = error {
@@ -861,7 +862,9 @@ class OctoPrintRESTClient {
         if let client = httpClient {
             let json : NSMutableDictionary = NSMutableDictionary()
             json["command"] = "update"
-            json["pin"] = id
+            json["version"] = 2
+            json["subject"] = id
+            json["pin"] = id // Backward compatibility to API v1
             client.post("/api/plugin/octorelay", json: json, expected: 200) { (result: NSObject?, error: Error?, response: HTTPURLResponse) in
                 callback(response.statusCode == 200, error, response)
             }


### PR DESCRIPTION
Closes #661 

This PR is featuring the support of the OctoRelay plugin's API v2 without loosing backward compatibility.

Changes:
- Including `version: 2` into each API request,
- When parsing the relay listing response, handle `status` entry (if present) with a fallback to ~~`active`~~ (deprecated),
- When switching a relay, including `subject` entry into request, as well as ~~`pin`~~ (deprecated)

Tested manually using: 
- Xcode 15.0.1
- Simulating IPhone SE (2n gen) running IOS 16.4
- OctoPrint 1.9.3
- OctoRelay 3.14.0

I'm new to Swift, so I'm open to any suggestions, corrections and advices.