### PR TITLE
Feature/uikit scene lifecycle

### DIFF
--- a/OctoPod.xcodeproj/project.pbxproj
+++ b/OctoPod.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		3D450EC921AB56F40049FBC0 /* IntentsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D450EC721AB56F40049FBC0 /* IntentsController.swift */; };
 		3D450ECB21AB5BCE0049FBC0 /* OctoPrintRESTClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAD2DDB21816D62004A4223 /* OctoPrintRESTClient.swift */; };
 		3D45280220E15A370094CCB7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D45280120E15A370094CCB7 /* AppDelegate.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* SceneDelegate.swift */; };
 		3D45280720E15A370094CCB7 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3D45280520E15A370094CCB7 /* Main.storyboard */; };
 		3D45280A20E15A370094CCB7 /* OctoPod.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3D45280820E15A370094CCB7 /* OctoPod.xcdatamodeld */; };
 		3D45280C20E15A380094CCB7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3D45280B20E15A380094CCB7 /* Assets.xcassets */; };
@@ -679,6 +680,7 @@
 		3D450EC721AB56F40049FBC0 /* IntentsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentsController.swift; sourceTree = "<group>"; };
 		3D4527FE20E15A370094CCB7 /* OctoPod.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OctoPod.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3D45280120E15A370094CCB7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		3D45280620E15A370094CCB7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		3D45280920E15A370094CCB7 /* OctoPod.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = OctoPod.xcdatamodel; sourceTree = "<group>"; };
 		3D45280B20E15A380094CCB7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1426,6 +1428,7 @@
 				3D831E542108540E0004B7A5 /* NavigationController.swift */,
 				3D6350F221083BE0001C10F7 /* TabBarController.swift */,
 				3D45280120E15A370094CCB7 /* AppDelegate.swift */,
+				A1B2C3D4E5F60718293A4B5D /* SceneDelegate.swift */,
 				3D8DA0192144716B00F5FD07 /* AppConfiguration.swift */,
 				3D42AC1021731494004D9FD0 /* AppConfigurationDelegate.swift */,
 				3D45280520E15A370094CCB7 /* Main.storyboard */,
@@ -2556,6 +2559,7 @@
 				3D49A09D21D41FE2005002E7 /* NotificationsManager.swift in Sources */,
 				084AC3332B0D5C0E00D99780 /* SpoolSelectionViewCell.swift in Sources */,
 				3D45280220E15A370094CCB7 /* AppDelegate.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* SceneDelegate.swift in Sources */,
 				3D968DE120E34612006774A5 /* PrinterDetailsViewController.swift in Sources */,
 				3D82873B20E407370035AE0B /* PrintersTableViewController.swift in Sources */,
 				3D67AA9525B51A3600302A2B /* Timelapse.swift in Sources */,

--- a/OctoPod/AppDelegate.swift
+++ b/OctoPod/AppDelegate.swift
@@ -10,41 +10,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     static let coreDataReadyNotification = Notification.Name("AppDelegate.coreDataReady")
 
+    // iOS 12 remains a supported deployment target. This outlet is unavailable on
+    // iOS 13 and later, where SceneDelegate exclusively owns the window.
+    @available(iOS, introduced: 2.0, obsoleted: 13.0)
     var window: UIWindow?
     private let coreDataReadinessLock = NSLock()
     private var coreDataReady = false
     private var coreDataStartupAttempted = false
+    // On iOS 13+, this is only a fallback for a legacy callback received before
+    // SceneDelegate has connected. The scene owns all other URL delivery.
     private var pendingOpenURL: URL?
+    private weak var sceneDelegate: AnyObject?
+    private var persistentStoreFailure = false
+    private var appWideServicesStarted = false
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Storyboard controllers resolve their dependencies lazily; keep them from becoming
-        // visible until the store and the legacy migration have both completed.
-        window?.isHidden = true
+        // iOS 13+ receives cold-start URLs in SceneDelegate.connectionOptions. Keep
+        // launchOptions URL ownership only for the legacy iOS 12 lifecycle.
+        if #unavailable(iOS 13.0) {
+            pendingOpenURL = launchOptions?[.url] as? URL
+            window?.isHidden = true
+        }
         _ = persistentContainer
         return true
-    }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-
-        // Start synchronizing with iCloud (if available)
-        if isCoreDataReady {
-            self.cloudKitPrinterManager.start(nil)
-        }
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
     func applicationWillTerminate(_ application: UIApplication) {
@@ -59,6 +47,55 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        receiveOpenURL(url)
+    }
+
+    // MARK: - Scene coordination
+
+    /// The app delegate owns app-wide state; the connected scene owns its window and UI.
+    /// OctoPod supports one scene configuration, so retaining the active delegate is enough
+    /// to bridge legacy UIApplicationDelegate URL delivery without reintroducing window ownership.
+    @available(iOS 13.0, *)
+    func connect(sceneDelegate: SceneDelegate) {
+        self.sceneDelegate = sceneDelegate
+        if persistentStoreFailure {
+            sceneDelegate.presentPersistentStoreFailure()
+            return
+        }
+        if isCoreDataReady {
+            sceneDelegate.coreDataDidBecomeReady()
+            deliverPendingOpenURLIfPossible()
+        }
+    }
+
+    @available(iOS 13.0, *)
+    func disconnect(sceneDelegate: SceneDelegate) {
+        if self.sceneDelegate === sceneDelegate {
+            self.sceneDelegate = nil
+        }
+    }
+
+    func sceneWillEnterForeground() {
+        // CloudKit is app-wide, but a foreground scene is the appropriate lifecycle
+        // signal to resume it. CloudKitPrinterManager coalesces overlapping starts.
+        guard isCoreDataReady else {
+            return
+        }
+        cloudKitPrinterManager.start(nil)
+    }
+
+    func receiveOpenURL(_ url: URL) -> Bool {
+        if #available(iOS 13.0, *) {
+            guard let sceneDelegate = sceneDelegate as? SceneDelegate else {
+                if url.scheme == "octopod" {
+                    pendingOpenURL = url
+                    return true
+                }
+                return false
+            }
+            // A connected scene queues URLs until its Core Data-backed UI is ready.
+            return sceneDelegate.openURL(url)
+        }
         guard isCoreDataReady else {
             if url.scheme == "octopod" {
                 pendingOpenURL = url
@@ -66,57 +103,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             return false
         }
-        return processOpenURL(url)
+        return processLegacyOpenURL(url)
     }
 
-    private func processOpenURL(_ url: URL) -> Bool {
-        if url.absoluteString.starts(with: "octopod://x-coredata") {
-            // iOS 16 sends with : and iOS 17 without. Use Regex to handle both cases
-            let newURL = url.absoluteString.replacingOccurrences(of: "octopod://x-coredata(:)*//", with: "x-coredata://", options: [.regularExpression])
-            // Switch to printer user clicked on when using LiveActivities
-            if let printerURL = URL(string: newURL), let printer = printerManager?.getPrinterByObjectURL(url: printerURL) {
-                // Add some delay so app transitions to Active (camera will render only when app is active)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self.defaultPrinterManager.changeToDefaultPrinter(printer: printer)
-                    
-                    // Go to main Panel window
-                    if let tabBarController = self.window!.rootViewController as? UITabBarController {
-                        tabBarController.selectedIndex = 0
-                    }
-                }
-                return true
-            }
-        } else if let printerName = url.host?.removingPercentEncoding {
-            // Switch to printer user clicked on when using Today's widget or notification or iOS 14 widget
-            if let printer = printerManager?.getPrinterByName(name: printerName) {
-                // Add some delay so app transitions to Active (camera will render only when app is active)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self.defaultPrinterManager.changeToDefaultPrinter(printer: printer)
-
-                    // Go to main Panel window
-                    if let tabBarController = self.window!.rootViewController as? UITabBarController {
-                        tabBarController.selectedIndex = 0
-                    }
-                }
-                return true
-            } else if printerName == "goToDashboard" {
-                // User clicked on iOS14 widget that shows multiple printers. Go to dashboard when user
-                // clicks on this widget
-                // Add some delay so app transitions to Active (camera will render only when app is active)
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if let tabBarController = self.window!.rootViewController as? UITabBarController {
-                        // Select main Panel window
-                        tabBarController.selectedIndex = 0
-                        if let navigationVC = tabBarController.selectedViewController as? NavigationController, let panelVC = navigationVC.topViewController as? PanelViewController {
-                            // Go to dashboard of printers
-                            panelVC.performSegue(withIdentifier: "printers_dashboard", sender: self)
-                        }
-                    }
-                }
-                return true
-            }
+    private func deliverPendingOpenURLIfPossible() {
+        guard isCoreDataReady, let pendingURL = pendingOpenURL else {
+            return
         }
-        return false
+        if #available(iOS 13.0, *) {
+            guard let sceneDelegate = sceneDelegate as? SceneDelegate else {
+                return
+            }
+            pendingOpenURL = nil
+            _ = sceneDelegate.openURL(pendingURL)
+        } else {
+            pendingOpenURL = nil
+            _ = processLegacyOpenURL(pendingURL)
+        }
     }
 
     // MARK: - Core Data stack
@@ -174,15 +177,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         coreDataReady = true
         coreDataReadinessLock.unlock()
 
-        // If no printers were defined then send to Setup window, if not go to first tab
-        if let tabBarController = self.window?.rootViewController as? UITabBarController {
-            tabBarController.selectedIndex = printerManager!.getPrinters().count == 0 ? 4 : 0
-        }
-
+        // Existing storyboard controllers may already be loaded but deferred their setup.
         NotificationCenter.default.post(name: AppDelegate.coreDataReadyNotification, object: self)
-        if let pendingURL = pendingOpenURL {
-            self.pendingOpenURL = nil
-            _ = processOpenURL(pendingURL)
+        startAppWideServicesIfNeeded()
+        if #available(iOS 13.0, *) {
+            (sceneDelegate as? SceneDelegate)?.coreDataDidBecomeReady()
+        } else {
+            finishLegacyCoreDataStartup()
+        }
+        deliverPendingOpenURLIfPossible()
+    }
+
+    private func startAppWideServicesIfNeeded() {
+        coreDataReadinessLock.lock()
+        let shouldStart = !appWideServicesStarted
+        appWideServicesStarted = true
+        coreDataReadinessLock.unlock()
+
+        guard shouldStart else {
+            return
         }
 
         // Register to receive push notifications via APNs (CloudKit sends silent push notifications when records change)
@@ -211,7 +224,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.ambient,
                                                          mode: AVAudioSession.Mode.moviePlayback,
                                                          options: [.mixWithOthers])
-        window?.makeKeyAndVisible()
     }
 
     private func beginCoreDataStartup() -> Bool {
@@ -225,6 +237,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func presentPersistentStoreFailure() {
+        persistentStoreFailure = true
+        if #available(iOS 13.0, *) {
+            (sceneDelegate as? SceneDelegate)?.presentPersistentStoreFailure()
+        } else {
+            presentLegacyPersistentStoreFailure()
+        }
+    }
+
+    // MARK: - iOS 12 compatibility
+
+    @available(iOS, introduced: 2.0, obsoleted: 13.0)
+    private func finishLegacyCoreDataStartup() {
+        if let tabBarController = window?.rootViewController as? UITabBarController {
+            tabBarController.selectedIndex = printerManager!.getPrinters().count == 0 ? 4 : 0
+        }
+        window?.makeKeyAndVisible()
+    }
+
+    @available(iOS, introduced: 2.0, obsoleted: 13.0)
+    private func presentLegacyPersistentStoreFailure() {
         let controller = UIViewController()
         controller.view.backgroundColor = .white
         let label = UILabel()
@@ -240,6 +272,53 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ])
         window?.rootViewController = controller
         window?.makeKeyAndVisible()
+    }
+
+    @available(iOS, introduced: 2.0, obsoleted: 13.0)
+    private func processLegacyOpenURL(_ url: URL) -> Bool {
+        guard url.scheme == "octopod" else {
+            return false
+        }
+        if url.absoluteString.starts(with: "octopod://x-coredata") {
+            let normalizedURL = url.absoluteString.replacingOccurrences(of: "octopod://x-coredata(:)*//",
+                                                                          with: "x-coredata://",
+                                                                          options: [.regularExpression])
+            if let printerURL = URL(string: normalizedURL),
+               let printer = printerManager?.getPrinterByObjectURL(url: printerURL) {
+                selectLegacyPrinterAndPanel(printer)
+                return true
+            }
+        } else if let printerName = url.host?.removingPercentEncoding {
+            if let printer = printerManager?.getPrinterByName(name: printerName) {
+                selectLegacyPrinterAndPanel(printer)
+                return true
+            } else if printerName == "goToDashboard" {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    guard let self = self,
+                          let tabBarController = self.window?.rootViewController as? UITabBarController else {
+                        return
+                    }
+                    tabBarController.selectedIndex = 0
+                    if let navigationVC = tabBarController.selectedViewController as? NavigationController,
+                       let panelVC = navigationVC.topViewController as? PanelViewController {
+                        panelVC.performSegue(withIdentifier: "printers_dashboard", sender: self)
+                    }
+                }
+                return true
+            }
+        }
+        return false
+    }
+
+    @available(iOS, introduced: 2.0, obsoleted: 13.0)
+    private func selectLegacyPrinterAndPanel(_ printer: Printer) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.defaultPrinterManager.changeToDefaultPrinter(printer: printer)
+            (self.window?.rootViewController as? UITabBarController)?.selectedIndex = 0
+        }
     }
     
     // Core Data database was moved from local storage to shared app group in release 2.1

--- a/OctoPod/Info.plist
+++ b/OctoPod/Info.plist
@@ -104,6 +104,25 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/OctoPod/Move UI/MoveSubViewController.swift
+++ b/OctoPod/Move UI/MoveSubViewController.swift
@@ -128,7 +128,7 @@ class MoveSubViewController: ThemedStaticUITableViewController, PrinterProfilesD
     }
     
     override func viewWillDisappear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+        super.viewWillDisappear(animated)
         
         // Stop listening to PrintProfile events
         octoprintClient.remove(printerProfilesDelegate: self)

--- a/OctoPod/Panel UI/Cameras/CamerasViewController.swift
+++ b/OctoPod/Panel UI/Cameras/CamerasViewController.swift
@@ -31,6 +31,7 @@ class CamerasViewController: UIViewController, UIPageViewControllerDataSource, U
     var muteAvailable = false
 
     private var lastPrinterID: String?
+    private weak var lastKnownWindow: UIWindow?
     
     /// PrinterURL of pritner to show. If empty then show default printer
     var showPrinter: String?
@@ -44,7 +45,9 @@ class CamerasViewController: UIViewController, UIPageViewControllerDataSource, U
         pageContainer.dataSource = self
 
         // Add it to the view
+        addChild(pageContainer)
         view.addSubview(pageContainer.view)
+        pageContainer.didMove(toParent: self)
 
         // Configure our custom pageControl
         view.bringSubviewToFront(pageControl)
@@ -60,6 +63,11 @@ class CamerasViewController: UIViewController, UIPageViewControllerDataSource, U
             lastPrinterID = newPrinterID
             updateViewControllersForPrinter(cameraChanged: cameraChanged)
         }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        lastKnownWindow = view.window
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -382,7 +390,7 @@ class CamerasViewController: UIViewController, UIPageViewControllerDataSource, U
         pipClosedCallback?()
         if userStartedPIP {
             // User closed PIP rather than doing a pop-in
-            if let tabBarController = (UIApplication.shared.delegate as! AppDelegate).window!.rootViewController as? UITabBarController {
+            if let tabBarController = sceneWindow?.rootViewController as? UITabBarController {
                 if tabBarController.selectedIndex == 0 && UIApplication.shared.applicationState == .active {
                     // We were already in Panel tab and app is in foregound so resume playing
                     pictureInPictureController.playerLayer.player?.play()
@@ -395,7 +403,7 @@ class CamerasViewController: UIViewController, UIPageViewControllerDataSource, U
     func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
         pipClosedCallback?()
         // We could be in any tab so go back to Panel tab AND camera started PIP
-        if let tabBarController = (UIApplication.shared.delegate as! AppDelegate).window!.rootViewController as? UITabBarController {
+        if let tabBarController = sceneWindow?.rootViewController as? UITabBarController {
             if tabBarController.selectedIndex != 0 {
                 // Stop player since view will appear and will start a new player
                 pictureInPictureController.playerLayer.player?.pause()
@@ -410,5 +418,18 @@ class CamerasViewController: UIViewController, UIPageViewControllerDataSource, U
         userStartedPIP = false
 
         completionHandler(true)
+    }
+
+    private var sceneWindow: UIWindow? {
+        let controllerWindow = view.window
+            ?? navigationController?.viewIfLoaded?.window
+            ?? tabBarController?.viewIfLoaded?.window
+            ?? parent?.viewIfLoaded?.window
+            ?? lastKnownWindow
+
+        guard #available(iOS 13.0, *), let windowScene = controllerWindow?.windowScene else {
+            return controllerWindow
+        }
+        return windowScene.windows.first(where: { $0.isKeyWindow }) ?? controllerWindow
     }
 }

--- a/OctoPod/SceneDelegate.swift
+++ b/OctoPod/SceneDelegate.swift
@@ -6,6 +6,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     private var pendingOpenURL: URL?
     private var coreDataUIReady = false
+    private var initialTabSelectionComplete = false
 
     private var appDelegate: AppDelegate {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
@@ -48,10 +49,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         coreDataUIReady = true
 
-        // If no printers are configured, use Setup; otherwise preserve the Panel tab.
-        rootTabBarController?.selectedIndex = appDelegate.printerManager!.getPrinters().count == 0 ? 4 : 0
         window?.makeKeyAndVisible()
-        replayPendingOpenURLIfPossible()
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            // Select a tab only after UIKit has attached the storyboard hierarchy to
+            // the visible scene window, avoiding an unbalanced appearance transition.
+            self.rootTabBarController?.selectedIndex = self.appDelegate.printerManager!.getPrinters().count == 0 ? 4 : 0
+            self.initialTabSelectionComplete = true
+            self.replayPendingOpenURLIfPossible()
+        }
     }
 
     func presentPersistentStoreFailure() {
@@ -76,7 +84,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard url.scheme == "octopod" else {
             return false
         }
-        guard coreDataUIReady else {
+        guard coreDataUIReady, initialTabSelectionComplete else {
             pendingOpenURL = url
             return true
         }

--- a/OctoPod/SceneDelegate.swift
+++ b/OctoPod/SceneDelegate.swift
@@ -1,0 +1,143 @@
+import UIKit
+
+@available(iOS 13.0, *)
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+    private var pendingOpenURL: URL?
+    private var coreDataUIReady = false
+
+    private var appDelegate: AppDelegate {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+            fatalError("OctoPod AppDelegate is unavailable")
+        }
+        return appDelegate
+    }
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+        guard scene is UIWindowScene else {
+            return
+        }
+
+        // The scene manifest loads Main.storyboard. Keep that window hidden until its
+        // Core Data-backed controllers have completed their deferred configuration.
+        window?.isHidden = true
+        pendingOpenURL = connectionOptions.urlContexts.first?.url
+        appDelegate.connect(sceneDelegate: self)
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        appDelegate.disconnect(sceneDelegate: self)
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        appDelegate.sceneWillEnterForeground()
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        for context in URLContexts {
+            _ = openURL(context.url)
+        }
+    }
+
+    func coreDataDidBecomeReady() {
+        guard !coreDataUIReady else {
+            return
+        }
+        coreDataUIReady = true
+
+        // If no printers are configured, use Setup; otherwise preserve the Panel tab.
+        rootTabBarController?.selectedIndex = appDelegate.printerManager!.getPrinters().count == 0 ? 4 : 0
+        window?.makeKeyAndVisible()
+        replayPendingOpenURLIfPossible()
+    }
+
+    func presentPersistentStoreFailure() {
+        let controller = UIViewController()
+        controller.view.backgroundColor = .white
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.text = "OctoPod could not open its saved data. Your saved data was not deleted. Please restart the app or check device storage and access settings."
+        label.translatesAutoresizingMaskIntoConstraints = false
+        controller.view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: controller.view.layoutMarginsGuide.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: controller.view.layoutMarginsGuide.trailingAnchor),
+            label.centerYAnchor.constraint(equalTo: controller.view.centerYAnchor)
+        ])
+        window?.rootViewController = controller
+        window?.makeKeyAndVisible()
+    }
+
+    func openURL(_ url: URL) -> Bool {
+        guard url.scheme == "octopod" else {
+            return false
+        }
+        guard coreDataUIReady else {
+            pendingOpenURL = url
+            return true
+        }
+
+        if url.absoluteString.starts(with: "octopod://x-coredata") {
+            // iOS 16 sends with ':' and iOS 17 without it.
+            let normalizedURL = url.absoluteString.replacingOccurrences(of: "octopod://x-coredata(:)*//",
+                                                                          with: "x-coredata://",
+                                                                          options: [.regularExpression])
+            if let printerURL = URL(string: normalizedURL),
+               let printer = appDelegate.printerManager?.getPrinterByObjectURL(url: printerURL) {
+                selectPrinterAndPanel(printer)
+                return true
+            }
+        } else if let printerName = url.host?.removingPercentEncoding {
+            if let printer = appDelegate.printerManager?.getPrinterByName(name: printerName) {
+                selectPrinterAndPanel(printer)
+                return true
+            } else if printerName == "goToDashboard" {
+                // Preserve the activation delay used to let camera views render after
+                // returning from a widget or Live Activity.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    self?.showDashboard()
+                }
+                return true
+            }
+        }
+        return false
+    }
+
+    private var rootTabBarController: UITabBarController? {
+        window?.rootViewController as? UITabBarController
+    }
+
+    private func replayPendingOpenURLIfPossible() {
+        guard let pendingOpenURL = pendingOpenURL else {
+            return
+        }
+        self.pendingOpenURL = nil
+        _ = openURL(pendingOpenURL)
+    }
+
+    private func selectPrinterAndPanel(_ printer: Printer) {
+        // Wait for the scene to become active so camera rendering remains reliable.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.appDelegate.defaultPrinterManager.changeToDefaultPrinter(printer: printer)
+            self.rootTabBarController?.selectedIndex = 0
+        }
+    }
+
+    private func showDashboard() {
+        guard let tabBarController = rootTabBarController else {
+            return
+        }
+        tabBarController.selectedIndex = 0
+        if let navigationVC = tabBarController.selectedViewController as? NavigationController,
+           let panelVC = navigationVC.topViewController as? PanelViewController {
+            panelVC.performSegue(withIdentifier: "printers_dashboard", sender: self)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Migrates OctoPod from the legacy AppDelegate-owned window lifecycle to UIScene while preserving the existing single-window behavior.

## Changes

- Adds SceneDelegate and scene manifest configuration.
- Keeps Core Data and app-wide services in AppDelegate.
- Moves window ownership, initial tab selection, failure UI, foreground routing, and scene URL handling to SceneDelegate.
- Preserves cold-start Live Activity and widget deep links.
- Retains the iOS 12 compatibility path.
- Fixes an unbalanced appearance transition during no-printer startup.
- Adds proper UIPageViewController containment.
- Makes PiP window lookup scene-aware.
- Corrects a lifecycle superclass call in MoveSubViewController.

## Validation

- Generic iOS build succeeded.
- Cold launch with and without configured printers.
- Cold-start Live Activity selects the encoded printer.
- Camera paging.
- Move screen enter/leave.
- No-printer startup warnings no longer reproduce.